### PR TITLE
Enhancement [API]: Adding better response feedback

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,6 +1,6 @@
 from flask import Flask, Blueprint
 from flask_cors import CORS
-from flask_restx import Api
+from flask_restx import Api, apidoc
 
 from api.api import api as translator_ns
 from person.views import api as person_ns
@@ -12,7 +12,12 @@ cors = CORS(app,
             ) # allow CORS for all domains on all routes.
 # app.config['CORS_HEADERS'] = 'Content-Type'
 
-blueprint = Blueprint('api', __name__, static_url_path='/extreme_auth')
+blueprint = Blueprint('api', __name__,
+                      static_url_path='/extreme_auth/swaggerui',
+                      url_prefix='/extreme_auth',
+                      root_path='/extreme_auth')
+
+apidoc.static_url_path = "/extreme_auth/swaggerui"
 app.register_blueprint(blueprint)
 
 authorizations = {

--- a/keycloak_interface/keycloakInterface.py
+++ b/keycloak_interface/keycloakInterface.py
@@ -268,9 +268,11 @@ class KeycloakInterface:
         return response, status_code
 
     def create_user(self, username: str, password: str, email: str, name: str):
-        user, created = get_or_create_keycloak_user(username, email, name, password, None)
-        if created:
-            return user, 201
-        return user, 200
-
-
+        try:
+            user, created = get_or_create_keycloak_user(username, email, name, password, None)
+            if created:
+                return user, 201
+            return user, 200
+        except Exception as e:
+            return {"error": "Internal Server Error",
+                    "error_description": "Unable to create user. Please check the date and try again."}, 500

--- a/keycloak_interface/utils/functions.py
+++ b/keycloak_interface/utils/functions.py
@@ -4,6 +4,9 @@ from keycloak_interface.utils.handlers import KeycloakHandler, KeyCloakRootConne
 def get_keycloak_user(username):
     return KeyCloakRootConnection().get_keycloak_user_id(username)
 
+def get_keycloak_user_by_email(email):
+    return KeyCloakRootConnection().get_keycloak_user_by_email(email)
+
 
 def get_keycloak_user_roles(user_id):
     roles = [role['name'] for role in KeyCloakRootConnection().get_user_role(user_id)]

--- a/keycloak_interface/utils/handlers.py
+++ b/keycloak_interface/utils/handlers.py
@@ -44,6 +44,13 @@ class KeycloakHandler:
     def set_user_role(self, user_id, role):
         self.keycloak_admin.assign_realm_roles(user_id, role)
 
+    def get_keycloak_user_by_email(self, email):
+        try:
+            users = self.keycloak_admin.get_users(query={"email": email, "max": 1, "exact": True})
+            return users[0] if len(users) == 1 else None
+        except Exception as e:
+            return None
+
     def get_keycloak_user(self, username):
         try:
             return self.keycloak_admin.get_user(self.keycloak_admin.get_user_id(username))

--- a/person/views.py
+++ b/person/views.py
@@ -1,10 +1,14 @@
+import json
+
 from flask import request
 from flask_restx import Namespace, Resource
+from keycloak import KeycloakPutError
 from requests import HTTPError
 
 from api import settings
 from keycloak_interface.errors import KeycloakACError, MissingTokenError
 from keycloak_interface.keycloakInterface import KeycloakInterface
+from keycloak_interface.utils.functions import get_keycloak_user, get_keycloak_user_by_email
 from models.models import PersonDAO
 
 api: Namespace = Namespace('Person', description='ExtremeXP Person Endpoints')
@@ -34,6 +38,15 @@ class PersonLoginView(Resource):
 
         try:
             response, status_code = keycloak_interface.authenticate(username, password)
+
+            if status_code != 200:
+                if get_keycloak_user(username) is not None:
+                    response["error_description"] = f"Invalid password"
+                    response["error_code"] = 4011
+                else:
+                    response["error_description"] = f"User not found"
+                    response["error_code"] = 4012
+
             return response, status_code
         except HTTPError as e:
             return {'error': str(e)}, 401
@@ -60,7 +73,7 @@ class PersonInfoView(Resource):
 
 
 @api.route("/register")
-class PersonLoginView(Resource):
+class PersonRegisterView(Resource):
     @api.doc('register', params={
         'username': 'Username',
         'password': 'Password',
@@ -81,6 +94,16 @@ class PersonLoginView(Resource):
                 email,
                 name
             )
+
+            if status_code != 201:
+                response = {"error": "Register conflict"}
+                status_code = 409
+                if get_keycloak_user(username) is not None:
+                    response["error_description"] = "Username already registered"
+                    response["error_code"] = 4091
+                elif get_keycloak_user_by_email(email) is not None:
+                    response["error_description"] = "Email already registered"
+                    response["error_code"] = 4092
             return response, status_code
-        except HTTPError as e:
-            return {'error': str(e)}, 401
+        except Exception as e:
+            return {'error': "Internal server error", "error_description": str(e), "error_code": 500}, 500


### PR DESCRIPTION
# Description
The PR adds new feedback for login and registration errors. This description details the feedback field updates.

## New feedback
The feedback now contains three new information fields: '_error_', '_error_description_', and '_error_code_'. It is also structured in JSON format to facilitate data handling. The possible outcomes for each endpoint are below.


> */extreme_auth/api/v1/person/login* → $${\color{orange}401}$$
```JSON
{
	"error": "invalid_grant",
	"error_description": "Invalid password",
	"error_code": 4011
}
```

```JSON
{
	"error": "invalid_grant",
	"error_description": "User not found",
	"error_code": 4012
}
```
---
> */extreme_auth/api/v1/person/register* → $${\color{orange}409}$$
```JSON
{
	"error": "Register conflict",
	"error_description": "Username already registered",
	"error_code": 4091
}
```
```JSON
{
	"error": "Register conflict",
	"error_description": "Email already registered",
	"error_code": 4092
}
```

### Notes
> **Note¹:** If you want simple feedback, use the "_error_description_" field. Otherwise, map to a chosen message using the "_error_code_".

> **Note²:** Every request returns 200 for OK, or 201 for CREATED. Any other response to the HTTP request can be considered an error and should be handled by the client. For Axios lib, use the _response.status_ field for validation ([see also](https://axios-http.com/docs/res_schema))